### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,23 @@
 {
-  "name": "roulette",
-  "version": "1.0.0",
+  "name": "roulette.js",
+  "version": "1.0.9",
   "main": "roulette.js",
   "ignore": [
     "**/.*",
     "node_modules",
     "components"
-  ]
+  ],
+  "authors": [
+    "akira-kuriyama"
+  ],
+  "description": "roulette.js is a jQuery Plugin for roulette image",
+  "keywords": [
+    "jquery",
+    "javascript",
+    "js",
+    "roulette",
+    "image"
+  ],
+  "license": "MIT",
+  "homepage": "http://demo.st-marron.info/roulette/sample/demo.html"
 }


### PR DESCRIPTION
I would like to use this plugin through bower and am currently registering it publicly. Thus the version in the bower.json (1.0.0) didn't match the latest tag (1.0.9).
This file change should make the bower usage more consistent.
