### PR TITLE
Fixed bug that called slowDownSetup method after stopped the reel

### DIFF
--- a/roulette.js
+++ b/roulette.js
@@ -5,7 +5,7 @@
 			speed : 10, // x > 0
 			stopImageNumber : null, // x >= 0 or null or -1
 			rollCount : 3, // x >= 0
-			duration : 3, //(x second)	
+			duration : 3, //(x second)
 			stopCallback : function() {
 			},
 			startCallback : function() {
@@ -31,6 +31,7 @@
 
 			distance : 0,
 			runUpDistance : null,
+			slowdownTimer : null,
 			isIE : navigator.userAgent.toLowerCase().indexOf('msie') > -1 // TODO IE
 		};
 		var p = $.extend({}, defaultSettings, options, defaultProperty);
@@ -43,8 +44,10 @@
 			p.isSlowdown = defaultProperty.isSlowdown;
 			p.isStop = defaultProperty.isStop;
 			p.topPosition = defaultProperty.topPosition;
+
+			clearTimeout(p.slowDownTimer);
 		}
-		
+
 		var slowDownSetup = function() {
 			if(p.isSlowdown){
 				return;
@@ -87,7 +90,7 @@
 			if (p.topPosition >= p.totalHeight) {
 				p.topPosition = p.topPosition - p.totalHeight;
 			}
-			// TODO IE 
+			// TODO IE
 			if (p.isIE) {
 				p.$rouletteTarget.css('top', '-' + p.topPosition + 'px');
 			} else {
@@ -114,7 +117,7 @@
 						// set BLANK image
 						this.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 						this.src = src;
-					}  
+					}
 				});
 			}
 			$roulette.find('div').remove();
@@ -137,10 +140,10 @@
 				return;
 			}
 			p.stopImageNumber = $.isNumeric(defaultProperty.originalStopImageNumber) && Number(defaultProperty.originalStopImageNumber) >= 0 ?
-									Number(defaultProperty.originalStopImageNumber) : Math.floor(Math.random() * p.imageCount); 
+									Number(defaultProperty.originalStopImageNumber) : Math.floor(Math.random() * p.imageCount);
 			p.startCallback();
 			roll();
-			setTimeout(function(){
+			p.slowDownTimer = setTimeout(function(){
 				slowDownSetup();
 			}, p.duration * 1000);
 		}
@@ -160,8 +163,8 @@
 			p = $.extend(p, options);
 			p.speed = Number(p.speed);
 			p.duration = Number(p.duration);
-			p.duration = p.duration > 1 ? p.duration - 1 : 1; 
-			defaultProperty.originalStopImageNumber = options.stopImageNumber; 
+			p.duration = p.duration > 1 ? p.duration - 1 : 1;
+			defaultProperty.originalStopImageNumber = options.stopImageNumber;
 		}
 
 		var ret = {


### PR DESCRIPTION
Call `clearTimeout()` in `reset()` method to clear timer for setting up slow down.

Fixed below issue.
![roullette](https://cloud.githubusercontent.com/assets/2577343/11971886/9307543a-a987-11e5-9b1f-7c10a06c28a9.gif)
